### PR TITLE
put parsers in a separate file

### DIFF
--- a/model.py
+++ b/model.py
@@ -3,29 +3,31 @@
 import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from dates import DateIndex
 
 
 class BrokerTransaction:
-    def __init__(self, row: List[str]):
-        assert len(row) == 9
-        assert row[8] == "", "should be empty"
-        as_of_str = " as of "
-        if as_of_str in row[0]:
-            index = row[0].find(as_of_str) + len(as_of_str)
-            date_str = row[0][index:]
-        else:
-            date_str = row[0]
-        self.date = datetime.datetime.strptime(date_str, "%m/%d/%Y").date()
-        self.action = row[1]
-        self.symbol = row[2]
-        self.description = row[3]
-        self.quantity = Decimal(row[4]) if row[4] != "" else None
-        self.price = Decimal(row[5].replace("$", "")) if row[5] != "" else None
-        self.fees = Decimal(row[6].replace("$", "")) if row[6] != "" else Decimal(0)
-        self.amount = Decimal(row[7].replace("$", "")) if row[7] != "" else None
+    def __init__(
+        self,
+        date: datetime.date,
+        action: str,
+        symbol: str,
+        description: str,
+        quantity: Optional[Decimal],
+        price: Optional[Decimal],
+        fees: Decimal,
+        amount: Optional[Decimal],
+    ):
+        self.date = date
+        self.action = action
+        self.symbol = symbol
+        self.description = description
+        self.quantity = quantity
+        self.price = price
+        self.fees = fees
+        self.amount = amount
 
     def __str__(self) -> str:
         result = f'date: {self.date}, action: "{self.action}"'
@@ -91,22 +93,6 @@ class ActionType(Enum):
             return ActionType.INTEREST
         else:
             raise Exception(f"Unknown action: {label}")
-
-
-class InitialPricesEntry:
-    def __init__(self, row: List[str]):
-        assert len(row) == 3
-        # date,symbol,price
-        self.date = self._parse_date(row[0])
-        self.symbol = row[1]
-        self.price = Decimal(row[2])
-
-    @staticmethod
-    def _parse_date(date_str: str) -> datetime.date:
-        return datetime.datetime.strptime(date_str, "%b %d, %Y").date()
-
-    def __str__(self) -> str:
-        return f"date: {self.date}, symbol: {self.symbol}, price: {self.price}"
 
 
 class RuleType(Enum):

--- a/parsers.py
+++ b/parsers.py
@@ -1,0 +1,83 @@
+import csv
+import datetime
+from decimal import Decimal
+from typing import Dict, List
+
+from dates import date_to_index
+from model import BrokerTransaction, DateIndex
+
+
+class InitialPricesEntry:
+    def __init__(self, row: List[str]):
+        assert len(row) == 3
+        # date,symbol,price
+        self.date = self._parse_date(row[0])
+        self.symbol = row[1]
+        self.price = Decimal(row[2])
+
+    @staticmethod
+    def _parse_date(date_str: str) -> datetime.date:
+        return datetime.datetime.strptime(date_str, "%b %d, %Y").date()
+
+    def __str__(self) -> str:
+        return f"date: {self.date}, symbol: {self.symbol}, price: {self.price}"
+
+
+class SchwabTransaction(BrokerTransaction):
+    def __init__(self, row: List[str]):
+        assert len(row) == 9
+        assert row[8] == "", "should be empty"
+        as_of_str = " as of "
+        if as_of_str in row[0]:
+            index = row[0].find(as_of_str) + len(as_of_str)
+            date_str = row[0][index:]
+        else:
+            date_str = row[0]
+        date = datetime.datetime.strptime(date_str, "%m/%d/%Y").date()
+        action = row[1]
+        symbol = row[2]
+        description = row[3]
+        quantity = Decimal(row[4]) if row[4] != "" else None
+        price = Decimal(row[5].replace("$", "")) if row[5] != "" else None
+        fees = Decimal(row[6].replace("$", "")) if row[6] != "" else Decimal(0)
+        amount = Decimal(row[7].replace("$", "")) if row[7] != "" else None
+        super().__init__(
+            date, action, symbol, description, quantity, price, fees, amount
+        )
+
+
+def read_broker_transactions(transactions_file: str) -> List[BrokerTransaction]:
+    with open(transactions_file) as csv_file:
+        lines = [line for line in csv.reader(csv_file)]
+        lines = lines[2:-1]
+        transactions = [SchwabTransaction(row) for row in lines]
+        transactions.reverse()
+        return list(transactions)
+
+
+def read_gbp_prices_history(gbp_history_file: str) -> Dict[int, Decimal]:
+    gbp_history: Dict[int, Decimal] = {}
+    with open(gbp_history_file) as csv_file:
+        lines = [line for line in csv.reader(csv_file)]
+        lines = lines[1:]
+        for row in lines:
+            assert len(row) == 2
+            price_date = datetime.datetime.strptime(row[0], "%m/%Y").date()
+            gbp_history[date_to_index(price_date)] = Decimal(row[1])
+    return gbp_history
+
+
+def read_initial_prices(
+    initial_prices_file: str,
+) -> Dict[DateIndex, Dict[str, Decimal]]:
+    initial_prices: Dict[DateIndex, Dict[str, Decimal]] = {}
+    with open(initial_prices_file) as csv_file:
+        lines = [line for line in csv.reader(csv_file)]
+        lines = lines[1:]
+        for row in lines:
+            entry = InitialPricesEntry(row)
+            date_index = date_to_index(entry.date)
+            if date_index not in initial_prices:
+                initial_prices[date_index] = {}
+            initial_prices[date_index][entry.symbol] = entry.price
+    return initial_prices


### PR DESCRIPTION
This moves all the parsers into `parsers.py`. This way `calc.py` is smaller and the parsing logic is isolated from the calculations.
This is part of a series of changes that will add (in this order):
- More verbose exception handling (I had a hard time debugging without it)
- Trading212 support (only needs a parser, the rest of the code stays the same)
- Removal of global variables (this is to make testing possible)
- Unit tests (because I want to be sure that my taxes are calculated right)

Let me know what you think about these too!