### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 ###############
 jobs:
   build:
-    name: super-linter
+    name: lint-and-test
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +24,12 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       ################################
       # Run Linter against code base #
@@ -34,3 +40,10 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      ################################
+      # Run pytest #
+      ################################
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .mypy_cache/
 __pycache__
+env

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Calculate capital gains tax by transaction history exported from Schwab/Trading2
 On Mac:
 ```shell
 brew install --cask mactex-no-gui
-pip3 install jinja2
+pip install -r requirements.txt
 ```
 
 ## Usage
@@ -24,6 +24,13 @@ pip3 install jinja2
 - `initial_prices.csv`: stock prices in USD at the moment of vesting, split, etc.
 - Run `python3 calc.py --tax_year 2020 --schwab schwab_transactions.csv --trading212 trading212/` (you can omit the brokers you don't use)
 - Use `python3 calc.py --help` for more details/options.
+
+## Testing
+
+```shell
+pip install pytest
+pytest
+```
 
 ## Disclaimer
 

--- a/args_parser.py
+++ b/args_parser.py
@@ -17,6 +17,7 @@ def create_parser() -> argparse.ArgumentParser:
     default_gbp_history_file = "GBP_USD_monthly_history.csv"
     # Initial vesting and spin-off prices
     default_initial_prices_file = "initial_prices.csv"
+    default_pdf_report = "calculations.pdf"
 
     parser = argparse.ArgumentParser(
         description="Calculate capital gains from stock transactions.",
@@ -54,5 +55,12 @@ def create_parser() -> argparse.ArgumentParser:
         default=default_initial_prices_file,
         nargs="?",
         help="file cointaining stock prices in USD at the moment of vesting, split, etc.",
+    )
+    parser.add_argument(
+        "--report",
+        type=str,
+        default=default_pdf_report,
+        nargs="?",
+        help="where to save the generated pdf report",
     )
     return parser

--- a/calc.py
+++ b/calc.py
@@ -228,6 +228,8 @@ class CapitalGainsCalculator:
                 transaction.fees = -transaction.amount
                 transaction.quantity = Decimal(0)
                 gbp_fees = self.converter.to_gbp_for(transaction.fees, transaction)
+                if transaction.symbol is None:
+                    raise SymbolMissingError(transaction)
                 CapitalGainsCalculator.add_to_list(
                     acquisition_list,
                     date_to_index(transaction.date),

--- a/calc.py
+++ b/calc.py
@@ -655,11 +655,13 @@ def main() -> int:
     # Second pass calculates capital gain tax for the given tax year
     report = calculator.calculate_capital_gain(acquisition_list, disposal_list)
     print(report)
-    render_latex.render_calculations(
-        report.calculation_log,
-        tax_year=report.tax_year,
-        date_from_index=date_from_index,
-    )
+    if args.report:
+        render_latex.render_calculations(
+            report.calculation_log,
+            tax_year=report.tax_year,
+            date_from_index=date_from_index,
+            output_file=args.report,
+        )
     print("All done!")
 
     return 0

--- a/model.py
+++ b/model.py
@@ -28,7 +28,7 @@ class BrokerTransaction:
         self,
         date: datetime.date,
         action: ActionType,
-        symbol: str,
+        symbol: Optional[str],
         description: str,
         quantity: Optional[Decimal],
         price: Optional[Decimal],

--- a/render_latex.py
+++ b/render_latex.py
@@ -14,7 +14,7 @@ calculations_template_file = "template.tex.j2"
 
 
 def render_calculations(
-    calculation_log: CalculationLog, tax_year: int, date_from_index
+    calculation_log: CalculationLog, tax_year: int, date_from_index, output_file: str
 ) -> None:
     print("Generate calculations report")
     current_directory = os.path.abspath(".")
@@ -57,3 +57,4 @@ def render_calculations(
     os.remove(generated_file)
     os.remove(f"{output_filename}.log")
     os.remove(f"{output_filename}.aux")
+    os.rename(output_filename + ".pdf", output_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2==2.11.3
+MarkupSafe==1.1.1

--- a/schwab.py
+++ b/schwab.py
@@ -57,7 +57,7 @@ class SchwabTransaction(BrokerTransaction):
         date = datetime.datetime.strptime(date_str, "%m/%d/%Y").date()
         self.raw_action = row[1]
         action = action_from_str(self.raw_action)
-        symbol = row[2]
+        symbol = row[2] if row[2] != "" else None
         description = row[3]
         quantity = Decimal(row[4]) if row[4] != "" else None
         price = Decimal(row[5].replace("$", "")) if row[5] != "" else None

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -226,7 +226,7 @@ def test_run_with_example_files():
     assert result.stderr == b"", "Run with example files generated errors"
     with open("tests/test_run_with_example_files_output.txt", "r") as file:
         expected = file.read()
-    assert result.stdout.decode('utf-8') == expected, (
+    assert result.stdout.decode("utf-8") == expected, (
         "Run with example files generated unexpected outputs, if you added new features update the test with:\n"
         + " python calc.py --report '' --schwab schwab_transactions.csv --trading212 trading212/"
         + " > tests/test_run_with_example_files_output.txt"

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,209 @@
+import datetime
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+import pytest
+from calc import CapitalGainsCalculator
+from currency_converter import CurrencyConverter
+from dates import date_to_index
+from initial_prices import InitialPrices
+from misc import round_decimal
+from model import ActionType, BrokerTransaction
+
+
+def get_report(calculator, broker_transactions):
+    acquisition_list, disposal_list = calculator.convert_to_hmrc_transactions(
+        broker_transactions
+    )
+    return calculator.calculate_capital_gain(acquisition_list, disposal_list)
+
+
+def buy_transaction(
+    date: datetime.date,
+    symbol: str,
+    quantity: float,
+    price: float,
+    fees: float,
+    amount: float,
+) -> BrokerTransaction:
+    return BrokerTransaction(
+        date,
+        ActionType.BUY,
+        symbol,
+        f"Description for symbol {symbol}",
+        Decimal(quantity),
+        Decimal(price),
+        Decimal(fees),
+        Decimal(amount),
+        "USD",
+        "Testing",
+    )
+
+
+def sell_transaction(
+    date: datetime.date,
+    symbol: str,
+    quantity: float,
+    price: float,
+    fees: float,
+    amount: float,
+) -> BrokerTransaction:
+    return BrokerTransaction(
+        date,
+        ActionType.SELL,
+        symbol,
+        f"Description for symbol {symbol}",
+        Decimal(quantity),
+        Decimal(price),
+        Decimal(fees),
+        Decimal(amount),
+        "USD",
+        "Testing",
+    )
+
+
+def transfer_transaction(
+    date: datetime.date,
+    amount: float,
+    fees: float = 0,
+) -> BrokerTransaction:
+    return BrokerTransaction(
+        date,
+        ActionType.TRANSFER,
+        symbol=None,
+        description="Test Transfer",
+        quantity=None,
+        price=None,
+        fees=Decimal(fees),
+        amount=Decimal(amount),
+        currency="USD",
+        broker="Testing",
+    )
+
+
+test_basic_data = [
+    pytest.param(
+        2020,  # tax year
+        [
+            transfer_transaction(datetime.date(day=1, month=5, year=2020), 5000),
+            buy_transaction(
+                date=datetime.date(day=1, month=5, year=2020),
+                symbol="FOO",
+                quantity=3,
+                price=5.0,
+                fees=1.0,
+                amount=-16.0,
+            ),
+            sell_transaction(
+                date=datetime.date(day=1, month=5, year=2020),
+                symbol="FOO",
+                quantity=3,
+                price=6.0,
+                fees=1.0,
+                amount=17.0,
+            ),
+        ],
+        1.00,  # Expected capital gain/loss
+        None,
+        id="same_day_gain",
+    ),
+    pytest.param(
+        2020,  # tax year
+        [
+            transfer_transaction(datetime.date(day=1, month=4, year=2014), 6280),
+            buy_transaction(
+                date=datetime.date(day=1, month=4, year=2014),
+                symbol="LOB",
+                quantity=1000,
+                price=4,
+                fees=150.0,
+                amount=-4150.0,
+            ),
+            buy_transaction(
+                date=datetime.date(day=1, month=9, year=2017),
+                symbol="LOB",
+                quantity=500,
+                price=4.1,
+                fees=80.0,
+                amount=-2130.0,
+            ),
+            sell_transaction(
+                date=datetime.date(day=1, month=5, year=2020),
+                symbol="LOB",
+                quantity=700,
+                price=4.8,
+                fees=100.0,
+                amount=3260.0,
+            ),
+            sell_transaction(
+                date=datetime.date(day=1, month=2, year=2021),
+                symbol="LOB",
+                quantity=400,
+                price=5.2,
+                fees=105.0,
+                amount=1975.0,
+            ),
+        ],
+        # exact amount would be £629+2/3
+        629.66,  # Expected capital gain/loss
+        None,
+        # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/972646/HS284_Example_3_2021.pdf
+        id="HS284_Example_3_2021",
+    ),
+    pytest.param(
+        2020,  # tax year
+        [
+            transfer_transaction(datetime.date(day=1, month=1, year=2019), 15100),
+            buy_transaction(
+                date=datetime.date(day=1, month=1, year=2019),
+                symbol="MSP",
+                quantity=9500,
+                price=1.5,
+                fees=0.0,
+                amount=-14250.0,
+            ),
+            sell_transaction(
+                date=datetime.date(day=30, month=8, year=2020),
+                symbol="MSP",
+                quantity=4000,
+                price=1.5,
+                fees=0.0,
+                amount=6000.0,
+            ),
+            buy_transaction(
+                date=datetime.date(day=11, month=9, year=2020),
+                symbol="MSP",
+                quantity=500,
+                price=1.7,
+                fees=0.0,
+                amount=-850.0,
+            ),
+        ],
+        -100,  # Expected capital gain/loss
+        None,
+        # https://www.gov.uk/government/publications/shares-and-capital-gains-tax-hs284-self-assessment-helpsheet/
+        id="HS284_Example_2_2021",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "tax_year,broker_transactions,expected,gbp_prices", test_basic_data
+)
+def test_basic(
+    tax_year: int,
+    broker_transactions: List[BrokerTransaction],
+    expected: float,
+    gbp_prices: Optional[Dict[int, Decimal]],
+):
+    if gbp_prices is None:
+        gbp_prices = {
+            date_to_index(t.date.replace(day=1)): Decimal(1)
+            for t in broker_transactions
+        }
+    converter = CurrencyConverter(gbp_prices)
+    initial_prices = InitialPrices({})
+    calculator = CapitalGainsCalculator(tax_year, converter, initial_prices)
+    report = get_report(calculator, broker_transactions)
+    print(report)
+    assert report.total_gain() == round_decimal(Decimal(expected), 2)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,4 +1,5 @@
 import datetime
+import subprocess
 from decimal import Decimal
 from typing import Dict, List, Optional
 
@@ -207,3 +208,16 @@ def test_basic(
     report = get_report(calculator, broker_transactions)
     print(report)
     assert report.total_gain() == round_decimal(Decimal(expected), 2)
+
+
+# runs the script and verifies it doesn't fail
+def test_run_with_example_files():
+    args = [
+        "--schwab",
+        "schwab_transactions.csv",
+        "--trading212",
+        "trading212/",
+        "--report",
+        "",
+    ]
+    subprocess.run(["python", "calc.py"] + args, check=True)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -220,4 +220,14 @@ def test_run_with_example_files():
         "--report",
         "",
     ]
-    subprocess.run(["python", "calc.py"] + args, check=True)
+    result = subprocess.run(
+        ["python", "calc.py"] + args, check=True, capture_output=True
+    )
+    assert result.stderr == b"", "Run with example files generated errors"
+    with open("tests/test_run_with_example_files_output.txt", "r") as file:
+        expected = file.read()
+    assert result.stdout.decode('utf-8') == expected, (
+        "Run with example files generated unexpected outputs, if you added new features update the test with:\n"
+        + " python calc.py --report '' --schwab schwab_transactions.csv --trading212 trading212/"
+        + " > tests/test_run_with_example_files_output.txt"
+    )

--- a/tests/test_run_with_example_files_output.txt
+++ b/tests/test_run_with_example_files_output.txt
@@ -1,0 +1,29 @@
+Parsing trading212/from_2020-09-11_to_2021-04-02.csv
+First pass completed
+Final portfolio:
+  GE: 1.00
+  NVDA: 1.00
+Final balance:
+  Charles Schwab: 10403.00 (USD)
+  Trading212: 33391.30 (GBP)
+Dividends: £0.10
+Dividend taxes: £0.00
+Interest: £0.00
+Disposal proceeds: £32453.25
+
+WARNING: Bed and breakfasting for FOO. Disposed on 2020-03-03 and acquired again on 2020-03-06
+
+Second pass completed
+Portfolio at the end of 2020/2021 tax year:
+  GE: 1.00, £8.07
+  NVDA: 1.00, £401.01
+For tax year 2020/2021:
+Number of disposals: 1
+Disposal proceeds: £32453.25
+Allowable costs: £7661.05
+Capital gain: £24792.20
+Capital loss: £0.00
+Total capital gain: £24792.20
+Taxable capital gain: £12492.20
+
+All done!

--- a/trading212.py
+++ b/trading212.py
@@ -65,7 +65,7 @@ class Trading212Transaction(BrokerTransaction):
         date = self.datetime.date()
         self.raw_action = row["Action"]
         action = action_from_str(self.raw_action, filename)
-        symbol = row["Ticker"]
+        symbol = row["Ticker"] if row["Ticker"] != "" else None
         description = row["Name"]
         quantity = decimal_or_none(row["No. of shares"])
         self.price_foreign = decimal_or_none(row["Price / share"])


### PR DESCRIPTION
This adds some unit tests, and makes them run in the CI too. There are three tests, two of them correspond to examples given by the HMRC (links provided). More tests should be added to increase coverage.

Tried to add one integration test that runs the script with the example files but installing `pdflatex` in the CI doesn't seem very straightforward at all.

(I had to make one small fix, symbol should be null for transfer transactions...)