### PR TITLE
Rename tax year argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ apt install texlive-latex-base
 -   `trading212/`: the exported transaction history from Trading212 since the beginning. Or at least since you first acquired the shares, which you were holding during the tax year. You can put several files here since Trading212 limit the statements to 1 year periods.
 -   `GBP_USD_monthly_history.csv`: monthly GBP/USD prices from [gov.uk](https://www.gov.uk/government/collections/exchange-rates-for-customs-and-vat).
 -   `initial_prices.csv`: stock prices in USD at the moment of vesting, split, etc.
--   Run `cgt-calc --tax_year 2020 --schwab schwab_transactions.csv --trading212 trading212/` (you can omit the brokers you don't use)
+-   Run `cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/` (you can omit the brokers you don't use)
 -   Use `cgt-calc --help` for more details/options.
 
 ## Disclaimer

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -15,14 +15,13 @@ def get_last_elapsed_tax_year() -> int:
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Calculate capital gains from stock transactions.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "--tax_year",
+        "--year",
         type=int,
         default=get_last_elapsed_tax_year(),
         nargs="?",
-        help="First year of the tax year to calculate gains on",
+        help="First year of the tax year to calculate gains on (default: %(default)d)",
     )
     parser.add_argument(
         "--schwab",
@@ -55,7 +54,7 @@ def create_parser() -> argparse.ArgumentParser:
         type=str,
         default=DEFAULT_REPORT_PATH,
         nargs="?",
-        help="where to save the generated pdf report",
+        help="where to save the generated pdf report (default: %(default)s)",
     )
     parser.add_argument(
         "--version",

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -637,7 +637,7 @@ def main() -> int:
     converter = CurrencyConverter(read_gbp_prices_history(args.gbp_history))
     initial_prices = InitialPrices(read_initial_prices(args.initial_prices))
 
-    calculator = CapitalGainsCalculator(args.tax_year, converter, initial_prices)
+    calculator = CapitalGainsCalculator(args.year, converter, initial_prices)
     # First pass converts broker transactions to HMRC transactions.
     # This means applying same day rule and collapsing all transactions with
     # same type in the same day.

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -218,7 +218,7 @@ def test_run_with_example_files():
         "poetry",
         "run",
         "cgt-calc",
-        "--tax_year",
+        "--year",
         "2020",
         "--schwab",
         "tests/test_data/schwab_transactions.csv",


### PR DESCRIPTION
- Use just `--year` for simplicity.
- Also don't always print defaults to avoid `default: None` and `default: False`.